### PR TITLE
fix navigation logic

### DIFF
--- a/mobile/sinhala_ed_app/lib/presentation/pages/profile_page.dart
+++ b/mobile/sinhala_ed_app/lib/presentation/pages/profile_page.dart
@@ -321,8 +321,8 @@ Future<void> _showLanguageDialog(BuildContext context) async {
   }
 }
 
-void _logout(BuildContext context) {
+void _logout(BuildContext context) async {
   final auth = context.read<AuthController>();
-  auth.signOut();
-  NavigationService.navigateToReplacement(AppRoutes.login);
+  await auth.signOut();
+  NavigationService.navigateToAndRemoveUntil(AppRoutes.login);
 }

--- a/mobile/sinhala_ed_app/lib/presentation/routes/navigation_service.dart
+++ b/mobile/sinhala_ed_app/lib/presentation/routes/navigation_service.dart
@@ -24,6 +24,13 @@ class NavigationService {
     );
   }
 
+  static Future<dynamic> navigateToAndRemoveUntil(String routeName) {
+    return navigatorKey.currentState!.pushNamedAndRemoveUntil(
+      routeName,
+      (route) => false,
+    );
+  }
+
   static void goBack() {
     return navigatorKey.currentState!.pop();
   }


### PR DESCRIPTION
This pull request improves the logout flow in the app by ensuring that after a user logs out, all previous navigation history is cleared and the user is redirected to the login screen. The changes also add a new navigation method to support this behavior.

**Logout flow improvements:**

* Updated the `_logout` function in `profile_page.dart` to await the sign-out process and use the new navigation method to clear navigation history when redirecting to the login screen.

**Navigation enhancements:**

* Added `navigateToAndRemoveUntil` method to `NavigationService` in `navigation_service.dart` to push a new route and remove all previous routes from the navigation stack.